### PR TITLE
Use ecr image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY ./dist /usr/share/nginx/html

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,3 +8,14 @@ tasks:
       - |
         aws cloudtrail lookup-events --lookup-attributes AttributeKey=ResourceName,AttributeValue={{.ATTRIBUTES}}  --max-items 1 \
         | jq -r '.Events[] | .CloudTrailEvent = (.CloudTrailEvent | fromjson ) | select(.EventName == "UpdateService") | {EventTime: .EventTime, EventName: .EventName, Deployments: .CloudTrailEvent.responseElements.service.deployments.[] | {Status: .status, TaskDefinition: .taskDefinition}}'
+  build_and_push:
+    desc: "DockerイメージをビルドしてECRにプッシュする"
+    vars:
+      PROJECT_NAME: "hamaguchi/nginx"
+      ECR_REPOSITORY: "533557086642.dkr.ecr.ap-northeast-1.amazonaws.com/{{.PROJECT_NAME}}"
+      IMAGE_TAG: "latest"
+    cmds:
+      - aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin {{.ECR_REPOSITORY}}
+      - docker build --build-arg project=app --platform linux/amd64 -t {{.PROJECT_NAME}} .
+      - docker tag {{.PROJECT_NAME}}:latest {{.ECR_REPOSITORY}}:{{.IMAGE_TAG}}
+      - docker push {{.ECR_REPOSITORY}}:{{.IMAGE_TAG}}

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <h1>revision:32</h1>
+</body>
+</html>

--- a/ecs.tf
+++ b/ecs.tf
@@ -30,7 +30,7 @@ resource "aws_ecs_task_definition" "nginx_task" {
   container_definitions = jsonencode([
     {
       name  = "nginx"
-      image = "public.ecr.aws/nginx/nginx:latest"
+      image = "${aws_ecr_repository.nginx.repository_url}:latest"
       portMappings = [
         {
           containerPort = 80
@@ -96,4 +96,12 @@ resource "aws_cloudwatch_log_group" "nginx_task" {
 resource "aws_ecr_pull_through_cache_rule" "ecr_public" {
   ecr_repository_prefix = "ecr-public"
   upstream_registry_url = "public.ecr.aws"
+}
+
+resource "aws_ecr_repository" "nginx" {
+  name = "hamaguchi/nginx"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -85,6 +85,9 @@ resource "aws_ecs_service" "nginx_service" {
     container_name   = "nginx"
     container_port   = 80
   }
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }
 
 resource "aws_cloudwatch_log_group" "nginx_task" {


### PR DESCRIPTION
タスクから使用されているイメージが判断できるかチェックするためにECRのイメージを使用するようにした

### 調査1
1. ECRにlatestタグでimageをプッシュ
1. 1のlatestタグを指定したタスクを起動
1. 内容を変更して再度latestタグで上書き
1. 2のタスクを再起動

この時、起動するタスクのイメージは1か3のイメージどちらが使用されるか？
->

- サービスの更新の場合
    - 「新しいデプロイの強制」を選択しないと同じタグを使用している場合デプロイが行われない（ref: https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/update-service-console-v2.html ）
- タスクを停止した場合
    - タスクを停止した場合、ECSのサービス定義を元にdesired countを満たすためのタスクが立ち上がるのでイメージを更新してもそれが使用されるわけではない
    

### 調査2
タスク定義上imageのタグが同じである場合、revisionでロールバックして以前のimageに戻すことは可能なのか？

```json
{
    "taskDefinitionArn": "arn:aws:ecs:ap-northeast-1:533557086642:task-definition/nginx_task:32",
    "containerDefinitions": [
        {
            "name": "nginx",
            "image": "533557086642.dkr.ecr.ap-northeast-1.amazonaws.com/hamaguchi/nginx:latest",
```

上記のように`latest`タグで指定されているので更新前のバージョンを特定することができない

```json
{
    "taskDefinitionArn": "arn:aws:ecs:ap-northeast-1:533557086642:task-definition/nginx_task:33",
    "containerDefinitions": [
        {
            "name": "nginx",
            "image": "533557086642.dkr.ecr.ap-northeast-1.amazonaws.com/hamaguchi/nginx@sha256:1f9d9ac286b9debb49a39f5c970e40dfb4209ed7301a21e7b85695fd12f56b32",
```

digest指定であればいける
